### PR TITLE
PHP Warning: Private methods cannot be final

### DIFF
--- a/libs/Characteristic/IsSingleton.php
+++ b/libs/Characteristic/IsSingleton.php
@@ -34,9 +34,8 @@ trait IsSingleton
 
 	/**
      * Private constructor to prevent creating a new instance of the *Singleton* via the `new` operator from outside of this class.
-	 * @final
      */
-	final private function __construct() 
+	private function __construct() 
 	{
 		$this->init();
 	}
@@ -45,17 +44,15 @@ trait IsSingleton
     /**
      * Private clone method to prevent cloning of the instance of the *Singleton* instance.
      * @return void
-	 * @final
      */
-	final private function __clone() {}
+	private function __clone() {}
 
 
     /**
      * Private unserialize method to prevent unserializing of the *Singleton* instance.
      * @return void
-	 * @final
      */
-	final private function __wakeup() {}
+	private function __wakeup() {}
 
 
 	/**


### PR DESCRIPTION
The Log Viewer shows this PHP warning:

> Private methods cannot be final as they are never overridden by other classes

<img width="795" alt="log-viewer" src="https://user-images.githubusercontent.com/7530507/141511966-fc67f069-8d1d-47b8-98cc-6e4529824b9e.png">
